### PR TITLE
add feature5

### DIFF
--- a/Composer/task5/task5/NodeCountVisitor.cs
+++ b/Composer/task5/task5/NodeCountVisitor.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace task5
+{
+    public class NodeCountVisitor : IVisitor
+    {
+        public int ElementCount { get; private set; }
+        public int TextNodeCount { get; private set; }
+
+        public void VisitElement(LightElementNode element)
+        {
+            ElementCount++;
+        }
+
+        public void VisitText(LightTextNode text)
+        {
+            TextNodeCount++;
+        }
+
+        public void PrintSummary()
+        {
+            Console.WriteLine($"[Visitor] Element nodes: {ElementCount}");
+            Console.WriteLine($"[Visitor] Text nodes: {TextNodeCount}");
+        }
+    }
+}

--- a/Composer/task5/task5/Program.cs
+++ b/Composer/task5/task5/Program.cs
@@ -1,30 +1,35 @@
-﻿using task5;
+﻿using System;
 
-static void Main(string[] args)
+namespace task5
 {
-    var root = new LightElementNode("div", DisplayType.Block, ClosureType.OpenAndClose);
-    root.AddCssClassInternal("hook-test");
-
-    var span = new LightElementNode("span", DisplayType.Inline, ClosureType.OpenAndClose);
-    root.AddChildInternal(span);
-
-    var txt = new LightTextNode("Hello Hooks!");
-    span.AddChildInternal(txt);
-
-    Console.WriteLine(root.OuterHTML);
-
-    foreach (var node in root.Traverse())
+    class Program
     {
-        Console.WriteLine(node.GetType().Name + ": " + node.OuterHTML);
+        static void Main(string[] args)
+        {
+            var root = new LightElementNode("div", DisplayType.Block, ClosureType.OpenAndClose);
+            root.AddCssClassInternal("hook-test");
+
+            var span = new LightElementNode("span", DisplayType.Inline, ClosureType.OpenAndClose);
+            root.AddChildInternal(span);
+
+            var txt = new LightTextNode("Hello Hooks!");
+            span.AddChildInternal(txt);
+
+            Console.WriteLine("\n[DOM]");
+            Console.WriteLine(root.OuterHTML);
+
+            Console.WriteLine("\n[Traversal]");
+            foreach (var node in root.Traverse())
+            {
+                Console.WriteLine(node.GetType().Name + ": " + node.OuterHTML);
+            }
+
+            Console.WriteLine("\n[Visitor]");
+            var visitor = new NodeCountVisitor();
+            root.Accept(visitor);
+            visitor.PrintSummary();
+
+            Console.ReadKey();
+        }
     }
-
-    Console.ReadKey();
-
-
-    var addClassCmd = new AddClassCommand(root, "hook-test");
-    var addChildCmd = new AddChildCommand(root, span);
-
-    addClassCmd.Execute();
-    addChildCmd.Execute();
-
 }


### PR DESCRIPTION
Ця фіча дозволяє відокремити поведінку (логіку) обробки вузлів DOM-дерева (LightElementNode, LightTextNode) від самих вузлів.
Використовується патерн Visitor, щоб реалізувати обхід і обробку дерева елементів без зміни самих класів вузлів.

Можна створювати власних "відвідувачів" (класи, які реалізують інтерфейс IVisitor), які роблять щось із HTML-деревом:

рахують елементи;

змінюють текст;

шукають помилки;

генерують статистику;

експортують у JSON, Markdown і т.п.

Логіка обробки — відділена від структури дерева (LightNode), що покращує масштабованість та підтримку коду.